### PR TITLE
Remove overriden label color, leaving all customisation to its implementer

### DIFF
--- a/UIAlertController-MZStyle/UIAlertController+MZStyle.m
+++ b/UIAlertController-MZStyle/UIAlertController+MZStyle.m
@@ -234,7 +234,6 @@ static NSMutableSet <Class> *instanceOfClassesSet = nil;
             if ([label.text isEqualToString:self.title] || [label.text isEqualToString:self.message]) {
                 
                 UILabel *newLabel = [self labelFromLabelAttributes:label];
-                newLabel.textColor = [UIColor whiteColor];
                 
                 [label.superview addSubview:newLabel];
                 


### PR DESCRIPTION
This predefined label color makes it imposible to customise label colors on iOS 8. Removing it and leaving all customisation to the implementation is a better option, I think.
